### PR TITLE
Do not store offsets against tableId in streaming mode

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -94,8 +94,9 @@ public final class SourceInfo extends BaseSourceInfo {
         return this;
     }
 
-    protected SourceInfo update(String tableUUID, String tabletId, OpId lsn) {
+    protected SourceInfo updateLSN(OpId lsn) {
         this.lsn = lsn;
+        return this;
     }
 
     /**

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -94,6 +94,10 @@ public final class SourceInfo extends BaseSourceInfo {
         return this;
     }
 
+    protected SourceInfo update(String tableUUID, String tabletId, OpId lsn) {
+        this.lsn = lsn;
+    }
+
     /**
      * Updates the source with the LSN of the last committed transaction.
      */

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -94,11 +94,6 @@ public final class SourceInfo extends BaseSourceInfo {
         return this;
     }
 
-    protected SourceInfo updateLSN(OpId lsn) {
-        this.lsn = lsn;
-        return this;
-    }
-
     /**
      * Updates the source with the LSN of the last committed transaction.
      */

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -46,17 +46,20 @@ public final class SourceInfo extends BaseSourceInfo {
     private String tableName;
     private String tabletId;
     private String tableUUID;
+    private boolean colocated;
 
     protected SourceInfo(YugabyteDBConnectorConfig connectorConfig) {
         super(connectorConfig);
         this.dbName = connectorConfig.databaseName();
     }
 
-    protected SourceInfo(YugabyteDBConnectorConfig connectorConfig, OpId lastCommitLsn) {
+    protected SourceInfo(YugabyteDBConnectorConfig connectorConfig, OpId lastCommitLsn,
+                         boolean colocated) {
         super(connectorConfig);
         this.dbName = connectorConfig.databaseName();
         this.lastCommitLsn = lastCommitLsn;
         this.lsn = lastCommitLsn;
+        this.colocated = colocated;
     }
 
     /**
@@ -148,6 +151,10 @@ public final class SourceInfo extends BaseSourceInfo {
 
     String tableName() {
         return tableName;
+    }
+
+    public boolean isColocated() {
+        return this.colocated;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -46,20 +46,17 @@ public final class SourceInfo extends BaseSourceInfo {
     private String tableName;
     private String tabletId;
     private String tableUUID;
-    private boolean colocated;
 
     protected SourceInfo(YugabyteDBConnectorConfig connectorConfig) {
         super(connectorConfig);
         this.dbName = connectorConfig.databaseName();
     }
 
-    protected SourceInfo(YugabyteDBConnectorConfig connectorConfig, OpId lastCommitLsn,
-                         boolean colocated) {
+    protected SourceInfo(YugabyteDBConnectorConfig connectorConfig, OpId lastCommitLsn) {
         super(connectorConfig);
         this.dbName = connectorConfig.databaseName();
         this.lastCommitLsn = lastCommitLsn;
         this.lsn = lastCommitLsn;
-        this.colocated = colocated;
     }
 
     /**
@@ -151,10 +148,6 @@ public final class SourceInfo extends BaseSourceInfo {
 
     String tableName() {
         return tableName;
-    }
-
-    public boolean isColocated() {
-        return this.colocated;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -71,7 +71,7 @@ public final class SourceInfo extends BaseSourceInfo {
      * @param xmin the xmin of the slot, may be null
      * @return this instance
      */
-    protected SourceInfo update(String tableUUID, String tabletId, OpId lsn, Instant commitTime, String txId,
+    protected SourceInfo update(YBPartition partition, OpId lsn, Instant commitTime, String txId,
                                 TableId tableId,
                                 Long xmin) {
         this.lsn = lsn;
@@ -86,8 +86,8 @@ public final class SourceInfo extends BaseSourceInfo {
         if (tableId != null && tableId.table() != null) {
             this.tableName = tableId.table();
         }
-        this.tableUUID = tableUUID;
-        this.tabletId = tabletId;
+        this.tableUUID = partition.getTableId();
+        this.tabletId = partition.getTabletId();
         return this;
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/SourceInfo.java
@@ -44,8 +44,6 @@ public final class SourceInfo extends BaseSourceInfo {
     private Instant timestamp;
     private String schemaName;
     private String tableName;
-    private String tabletId;
-    private String tableUUID;
 
     protected SourceInfo(YugabyteDBConnectorConfig connectorConfig) {
         super(connectorConfig);
@@ -86,8 +84,6 @@ public final class SourceInfo extends BaseSourceInfo {
         if (tableId != null && tableId.table() != null) {
             this.tableName = tableId.table();
         }
-        this.tableUUID = partition.getTableId();
-        this.tabletId = partition.getTabletId();
         return this;
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -25,9 +25,17 @@ public class YBPartition implements Partition {
     private final String tabletId;
     private final String tableId;
 
+    private boolean isTableColocated;
+
     public YBPartition(String tableId, String tabletId) {
         this.tableId = tableId;
         this.tabletId = tabletId;
+    }
+
+    public YBPartition(String tableId, String tabletId, boolean isTableColocated) {
+        this.tableId = tableId;
+        this.tabletId = tabletId;
+        this.isTableColocated = isTableColocated;
     }
 
     @Override
@@ -48,7 +56,20 @@ public class YBPartition implements Partition {
      * the same thing as using {@code p.getTableId() + "." + p.getTabletId()}
      */
     public String getId() {
-        return this.tableId + "." + this.tabletId;
+        if (!isTableColocated()) {
+            // If table is not colocated, we need to process the table just by its tablet ID.
+            return getTabletId();
+        }
+
+        return getTableId() + "." + getTabletId();
+    }
+
+    public boolean isTableColocated() {
+        return this.isTableColocated;
+    }
+
+    public void markTableAsColocated() {
+        this.isTableColocated = true;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -59,11 +59,6 @@ public class YBPartition implements Partition {
      * the same thing as using {@code p.getTableId() + "." + p.getTabletId()}
      */
     public String getId() {
-//        if (!isTableColocated()) {
-//            // If table is not colocated, we need to process the table just by its tablet ID.
-//            return getTabletId();
-//        }
-
         return getTableId() + "." + getTabletId();
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -25,7 +25,7 @@ public class YBPartition implements Partition {
     private final String tabletId;
     private final String tableId;
 
-    private final boolean isTableColocated;
+    private boolean isTableColocated;
 
     public YBPartition(String tableId, String tabletId) {
         this.tableId = tableId;

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -56,10 +56,10 @@ public class YBPartition implements Partition {
      * the same thing as using {@code p.getTableId() + "." + p.getTabletId()}
      */
     public String getId() {
-        if (!isTableColocated()) {
-            // If table is not colocated, we need to process the table just by its tablet ID.
-            return getTabletId();
-        }
+//        if (!isTableColocated()) {
+//            // If table is not colocated, we need to process the table just by its tablet ID.
+//            return getTabletId();
+//        }
 
         return getTableId() + "." + getTabletId();
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -98,7 +98,7 @@ public class YBPartition implements Partition {
 
     @Override
     public int hashCode() {
-        return getId().hashCode();
+        return getFullPartitionName().hashCode();
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -25,11 +25,14 @@ public class YBPartition implements Partition {
     private final String tabletId;
     private final String tableId;
 
-    private boolean isTableColocated;
+    private final boolean isTableColocated;
 
     public YBPartition(String tableId, String tabletId) {
         this.tableId = tableId;
         this.tabletId = tabletId;
+
+        // By default, assume that the table is not colocated.
+        this.isTableColocated = false;
     }
 
     public YBPartition(String tableId, String tabletId, boolean isTableColocated) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -25,20 +25,20 @@ public class YBPartition implements Partition {
     private final String tabletId;
     private final String tableId;
 
-    private boolean isTableColocated;
+    private boolean colocated;
 
     public YBPartition(String tableId, String tabletId) {
         this.tableId = tableId;
         this.tabletId = tabletId;
 
         // By default, assume that the table is not colocated.
-        this.isTableColocated = false;
+        this.colocated = false;
     }
 
     public YBPartition(String tableId, String tabletId, boolean isTableColocated) {
         this.tableId = tableId;
         this.tabletId = tabletId;
-        this.isTableColocated = isTableColocated;
+        this.colocated = isTableColocated;
     }
 
     @Override
@@ -59,19 +59,28 @@ public class YBPartition implements Partition {
      * colocated) or {@code tabletId} (if table is not colocated)
      */
     public String getId() {
-        if (!isTableColocated) {
+        if (!isTableColocated()) {
             return getTabletId();
         }
 
+        return getFullPartitionName();
+    }
+
+    /**
+     * Get the full ID of this partition identified by {@code tableId.tabletId} - this will be used
+     * to form the metric names.
+     * @return
+     */
+    public String getFullPartitionName() {
         return getTableId() + "." + getTabletId();
     }
 
     public boolean isTableColocated() {
-        return this.isTableColocated;
+        return this.colocated;
     }
 
     public void markTableAsColocated() {
-        this.isTableColocated = true;
+        this.colocated = true;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -59,7 +59,7 @@ public class YBPartition implements Partition {
      * colocated) or {@code tabletId} (if table is not colocated)
      */
     public String getId() {
-        if (isTableColocated) {
+        if (!isTableColocated) {
             return getTabletId();
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YBPartition.java
@@ -55,10 +55,14 @@ public class YBPartition implements Partition {
     }
 
     /**
-     * @return the ID of this partition in the format {@code tableId.tabletId}, this is essentially
-     * the same thing as using {@code p.getTableId() + "." + p.getTabletId()}
+     * @return the ID of this partition in the format {@code tableId.tabletId} (if table is
+     * colocated) or {@code tabletId} (if table is not colocated)
      */
     public String getId() {
+        if (isTableColocated) {
+            return getTabletId();
+        }
+
         return getTableId() + "." + getTabletId();
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBChangeEventSourceCoordinator.java
@@ -109,6 +109,12 @@ public class YugabyteDBChangeEventSourceCoordinator extends ChangeEventSourceCoo
 
             if (snapshotResult.isCompletedOrSkipped()) {
                 streamingOffsets.getOffsets().put(partition, snapshotResult.getOffset());
+
+                // Further down the processing unit, we are retrieving all the partitions even
+                // though we pass just one at this level, so in case the snapshot gets completed
+                // for one, it would be safe to break out of this loop to avoid processing things
+                // again.
+                break;
             }
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -11,12 +11,12 @@ import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.*;
 
+import io.debezium.connector.yugabytedb.util.YugabyteDBConnectorUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.util.ConnectorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.cdc.CdcService.TabletCheckpointPair;
@@ -145,7 +145,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         int numGroups = Math.min(this.tabletIds.size(), maxTasks);
         LOGGER.debug("The tabletIds size are " + tabletIds.size() + " maxTasks" + maxTasks);
 
-        List<List<Pair<String, String>>> tabletIdsGrouped = ConnectorUtils.groupPartitions(this.tabletIds, numGroups);
+        List<List<Pair<String, String>>> tabletIdsGrouped = YugabyteDBConnectorUtils.groupPartitionsSmartly(this.tabletIds, numGroups);
         LOGGER.debug("The grouped tabletIds are " + tabletIdsGrouped.size());
         List<Map<String, String>> taskConfigs = new ArrayList<>(tabletIdsGrouped.size());
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -182,8 +182,15 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                         .store(transactionContext.store(result));
     }
 
-    public Struct getSourceInfoForTablet(String tableId, String tabletId) {
+    public Struct getSourceInfoForTablet(String tableId, String tabletId, boolean ignoreTableUUID) {
+        if (ignoreTableUUID) {
+            return this.tabletSourceInfo.get(tabletId).struct();
+        }
+
         return this.tabletSourceInfo.get(tableId + "." + tabletId).struct();
+    }
+    public Struct getSourceInfoForTablet(String tableId, String tabletId) {
+        return getSourceInfoForTablet(tableId, tabletId, false /* ignoreTableUUID */);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -92,7 +92,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                 this.lastCommitLsn = c.lastCommitLsn;
                 String tableUUID = context.getKey().getTableId();
                 String tabletId = context.getKey().getTabletId();
-                initSourceInfo(tableUUID, tabletId, config);
+                initSourceInfo(tableUUID, tabletId, config, c.lastCompletelyProcessedLsn, context.getKey().isTableColocated());
                 this.updateWalPosition(tableUUID, tabletId,
                         this.lastCommitLsn, lastCompletelyProcessedLsn, null, null, null, null);
             }
@@ -150,7 +150,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                     context.markTableNonColocated(p.getTableId());
                 }
 
-                context.initSourceInfo(p.getTableId(), p.getTabletId(), connectorConfig);
+                context.initSourceInfo(p.getTableId(), p.getTabletId(), connectorConfig, lastCompletelyProcessedLsn, p.isTableColocated());
                 context.updateWalPosition(p.getTableId(), p.getTabletId(), lastCommitLsn, lastCompletelyProcessedLsn, clock.currentTimeAsInstant(), String.valueOf(txId), null, null);
             }
         }
@@ -293,9 +293,9 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.tabletSourceInfo.put(lookupPrefix + tabletId, info);
     }
 
-    public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig) {
-        this.tabletSourceInfo.put(tableUUID + "." + tabletId, new SourceInfo(connectorConfig));
-    }
+//    public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig) {
+//        this.tabletSourceInfo.put(tableUUID + "." + tabletId, new SourceInfo(connectorConfig));
+//    }
 
     public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig, OpId opId,
                                boolean colocated) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -227,7 +227,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         if (!tableColocationInfo.get(tableId)) {
             SourceInfo info = tabletSourceInfo.get(tabletId);
             if (info == null) {
-                tabletSourceInfo.put(tabletId, new SourceInfo(connectorConfig, YugabyteDBOffsetContext.streamingStartLsn(), false));
+                tabletSourceInfo.put(tabletId, new SourceInfo(connectorConfig, YugabyteDBOffsetContext.streamingStartLsn()));
             }
             return tabletSourceInfo.get(tabletId);
         }
@@ -275,7 +275,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         // to retrieve a SourceInfo which may not be available in the map as we will just be looking
         // up using the tabletId. Store the SourceInfo in that case.
         if (info == null) {
-            info = new SourceInfo(connectorConfig, lsn, tableColocationInfo.get(tableUUID));
+            info = new SourceInfo(connectorConfig, lsn);
         }
 
         info.update(lookupPrefix, tabletId, lsn, commitTime, txId, tableId, xmin);
@@ -285,7 +285,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig, OpId opId,
                                boolean colocated) {
         this.tableColocationInfo.put(tableUUID, colocated);
-        this.tabletSourceInfo.put((colocated ? tableUUID + "." : "") + tabletId, new SourceInfo(connectorConfig, opId, colocated));
+        this.tabletSourceInfo.put((colocated ? tableUUID + "." : "") + tabletId, new SourceInfo(connectorConfig, opId));
     }
 
     public Map<String, SourceInfo> getTabletSourceInfo() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -188,18 +188,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         }
 
         for (Map.Entry<String, SourceInfo> entry : this.tabletSourceInfo.entrySet()) {
-            // The entry.getKey() here would be tableId.tabletId
-            if (entry.getKey() == null) {
-                LOGGER.info("entry.getKey is null");
-            }
-
-            if (entry.getValue() == null) {
-                LOGGER.info("entry.getValue() is null for {}", entry.getKey());
-            }
-
-            if (entry.getValue().lsn() == null) {
-                LOGGER.info("entry.getValue().lsn() is null for {}", entry.getKey());
-            }
+            // The entry.getKey() here would be tableId.tabletId or just tabletId
             result.put(entry.getKey(), entry.getValue().lsn().toSerString());
         }
 
@@ -293,10 +282,6 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.tabletSourceInfo.put(lookupPrefix + tabletId, info);
     }
 
-//    public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig) {
-//        this.tabletSourceInfo.put(tableUUID + "." + tabletId, new SourceInfo(connectorConfig));
-//    }
-
     public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig, OpId opId,
                                boolean colocated) {
         this.tableColocationInfo.put(tableUUID, colocated);
@@ -307,13 +292,10 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         return tabletSourceInfo;
     }
 
-    public void updateCommitPosition(String tableUUID, String tabletId, OpId lsn,
-                                     OpId lastCompletelyProcessedLsn) {
+    public void updateCommitPosition(OpId lsn, OpId lastCompletelyProcessedLsn) {
         this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
         this.lastCommitLsn = lsn;
         sourceInfo.updateLastCommit(lsn);
-        SourceInfo info = getSourceInfo(tableUUID, tabletId);
-        info.updateLSN(lsn);
     }
 
     boolean hasLastKnownPosition() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -202,6 +202,10 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public SourceInfo getSourceInfo(String tableId, String tabletId, boolean ignoreTableUUID) {
         if (ignoreTableUUID) {
+            SourceInfo info = tabletSourceInfo.get(tabletId);
+            if (info == null) {
+                tabletSourceInfo.put(tabletId, new SourceInfo(connectorConfig));
+            }
             return tabletSourceInfo.get(tabletId);
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -307,10 +307,13 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         return tabletSourceInfo;
     }
 
-    public void updateCommitPosition(OpId lsn, OpId lastCompletelyProcessedLsn) {
+    public void updateCommitPosition(String tableUUID, String tabletId, OpId lsn,
+                                     OpId lastCompletelyProcessedLsn) {
         this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
         this.lastCommitLsn = lsn;
         sourceInfo.updateLastCommit(lsn);
+        SourceInfo info = getSourceInfo(tableUUID, tabletId);
+        info.update(tableUUID, tabletId, lsn);
     }
 
     boolean hasLastKnownPosition() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -170,10 +170,6 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     public Map<String, ?> getOffset() {
         Map<String, Object> result = new HashMap<>();
 
-        if (this.tabletSourceInfo == null) {
-            LOGGER.info("tablet source Info is null");
-        }
-
         for (Map.Entry<String, SourceInfo> entry : this.tabletSourceInfo.entrySet()) {
             // The entry.getKey() here would be tableId.tabletId or just tabletId
             result.put(entry.getKey(), entry.getValue().lsn().toSerString());
@@ -199,6 +195,11 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     }
 
     public SourceInfo getSourceInfo(YBPartition partition) {
+        SourceInfo info = tabletSourceInfo.get(partition.getId());
+        if (info == null) {
+            tabletSourceInfo.put(partition.getId(), new SourceInfo(connectorConfig, YugabyteDBOffsetContext.streamingStartLsn()));
+        }
+
         return tabletSourceInfo.get(partition.getId());
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -146,6 +146,8 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                 // colocated, utilize the same information to further initialize context.
                 if (p.isTableColocated()) {
                     context.markTableAsColocated(p.getTableId());
+                } else {
+                    context.markTableNonColocated(p.getTableId());
                 }
 
                 context.initSourceInfo(p.getTableId(), p.getTabletId(), connectorConfig);
@@ -201,6 +203,10 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public void markTableAsColocated(String tableUUID) {
         this.tableColocationInfo.put(tableUUID, true);
+    }
+
+    public void markTableNonColocated(String tableUUID) {
+        this.tableColocationInfo.put(tableUUID, false);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -231,9 +231,6 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                                   String txId, TableId tableId, Long xmin) {
         this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
 
-        // Only use the tableUUID as the prefix in case the table is colocated.
-        String lookupPrefix = partition.isTableColocated() ? partition.getTableId() + "." : "";
-
         sourceInfo.update(partition, lsn, commitTime, txId, tableId, xmin);
         SourceInfo info = this.tabletSourceInfo.get(partition.getId());
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -313,7 +313,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         this.lastCommitLsn = lsn;
         sourceInfo.updateLastCommit(lsn);
         SourceInfo info = getSourceInfo(tableUUID, tabletId);
-        info.update(tableUUID, tabletId, lsn);
+        info.updateLSN(lsn);
     }
 
     boolean hasLastKnownPosition() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -214,7 +214,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         if (!tableColocationInfo.get(tableId)) {
             SourceInfo info = tabletSourceInfo.get(tabletId);
             if (info == null) {
-                tabletSourceInfo.put(tabletId, new SourceInfo(connectorConfig));
+                tabletSourceInfo.put(tabletId, new SourceInfo(connectorConfig, YugabyteDBOffsetContext.streamingStartLsn(), false));
             }
             return tabletSourceInfo.get(tabletId);
         }
@@ -273,6 +273,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig, OpId opId,
                                boolean colocated) {
+        this.tableColocationInfo.put(tableUUID, colocated);
         this.tabletSourceInfo.put((colocated ? tableUUID + "." : "") + tabletId, new SourceInfo(connectorConfig, opId, colocated));
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -183,8 +183,19 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     public Map<String, ?> getOffset() {
         Map<String, Object> result = new HashMap<>();
 
+        if (this.tabletSourceInfo == null) {
+            LOGGER.info("tablet source Info is null");
+        }
+
         for (Map.Entry<String, SourceInfo> entry : this.tabletSourceInfo.entrySet()) {
             // The entry.getKey() here would be tableId.tabletId
+            if (entry.getKey() == null) {
+                LOGGER.info("entry.getKey is null");
+            }
+
+            if (entry.getValue() == null) {
+                LOGGER.info("entry.getValue() is null for {}", entry.getKey());
+            }
             result.put(entry.getKey(), entry.getValue().lsn().toSerString());
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -196,6 +196,10 @@ public class YugabyteDBOffsetContext implements OffsetContext {
             if (entry.getValue() == null) {
                 LOGGER.info("entry.getValue() is null for {}", entry.getKey());
             }
+
+            if (entry.getValue().lsn() == null) {
+                LOGGER.info("entry.getValue().lsn() is null for {}", entry.getKey());
+            }
             result.put(entry.getKey(), entry.getValue().lsn().toSerString());
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -240,7 +240,6 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         // to retrieve a SourceInfo which may not be available in the map as we will just be looking
         // up using the tabletId. Store the SourceInfo in that case.
         if (info == null) {
-            LOGGER.info("Info is null for ID {}, creating a new sourceinfo", partition.getId());
             info = new SourceInfo(connectorConfig, lsn);
         }
 
@@ -249,7 +248,6 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     }
 
     public void initSourceInfo(YBPartition partition, YugabyteDBConnectorConfig connectorConfig, OpId opId) {
-        LOGGER.info("Initializing source info for partition {}", partition);
         this.tabletSourceInfo.put(partition.getId(), new SourceInfo(connectorConfig, opId));
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -273,7 +273,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig, OpId opId,
                                boolean colocated) {
-        this.tabletSourceInfo.put(tableUUID + "." + tabletId, new SourceInfo(connectorConfig, opId, colocated));
+        this.tabletSourceInfo.put(colocated ? (tableUUID + ".") : "" + tabletId, new SourceInfo(connectorConfig, opId, colocated));
     }
 
     public Map<String, SourceInfo> getTabletSourceInfo() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -273,7 +273,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
 
     public void initSourceInfo(String tableUUID, String tabletId, YugabyteDBConnectorConfig connectorConfig, OpId opId,
                                boolean colocated) {
-        this.tabletSourceInfo.put(colocated ? (tableUUID + ".") : "" + tabletId, new SourceInfo(connectorConfig, opId, colocated));
+        this.tabletSourceInfo.put((colocated ? tableUUID + "." : "") + tabletId, new SourceInfo(connectorConfig, opId, colocated));
     }
 
     public Map<String, SourceInfo> getTabletSourceInfo() {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBOffsetContext.java
@@ -109,6 +109,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
                                                          YugabyteDBConnection jdbcConnection,
                                                          Clock clock,
                                                          Set<YBPartition> partitions) {
+        LOGGER.info("Initializing streaming context");
         return initialContext(connectorConfig, jdbcConnection, clock, streamingStartLsn(),
                               streamingStartLsn(), partitions);
     }
@@ -238,6 +239,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
         // to retrieve a SourceInfo which may not be available in the map as we will just be looking
         // up using the tabletId. Store the SourceInfo in that case.
         if (info == null) {
+            LOGGER.info("Info is null for ID {}, creating a new sourceinfo", partition.getId());
             info = new SourceInfo(connectorConfig, lsn);
         }
 
@@ -246,6 +248,7 @@ public class YugabyteDBOffsetContext implements OffsetContext {
     }
 
     public void initSourceInfo(YBPartition partition, YugabyteDBConnectorConfig connectorConfig, OpId opId) {
+        LOGGER.info("Initializing source info for partition {}", partition);
         this.tabletSourceInfo.put(partition.getId(), new SourceInfo(connectorConfig, opId));
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -121,10 +121,6 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         try {
             snapshotProgressListener.snapshotStarted(partition);
             Set<YBPartition> partitions = new YBPartition.Provider(connectorConfig).getPartitions();
-            LOGGER.info("Partitions received in getPartitions:");
-            for (YBPartition ppp : partitions) {
-              LOGGER.info(ppp.toString());
-            }
 
             // For snapshot, set all partitions to use tableID as identifier.
             partitions.forEach(YBPartition::markTableAsColocated);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -427,10 +427,12 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                         Objects.requireNonNull(tId);
                       }
 
+                      // In case of snapshots, we do not want to ignore tableUUID while updating
+                      // OpId value for a table-tablet pair.
                       previousOffset.updateWalPosition(tableUUID, tabletId, lsn, lastCompletelyProcessedLsn,
                                                        message.getCommitTime(), 
                                                        String.valueOf(message.getTransactionId()), 
-                                                       tId, null);
+                                                       tId, null, false /* ignoreTableUUID */);
                       
                       boolean dispatched = (message.getOperation() != Operation.NOOP) && 
                           dispatcher.dispatchDataChangeEvent(part, tId, 
@@ -493,7 +495,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                     taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(tableUUID + "." + tabletId) : null);
                 }
                 
-                previousOffset.getSourceInfo(tableUUID, tabletId).updateLastCommit(finalOpId);
+                previousOffset.getSourceInfo(tableUUID, tabletId, false /* ignoreTableUUID */)
+                              .updateLastCommit(finalOpId);
             }
             
             // Reset the retry count here indicating that if the flow has reached here then

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -344,7 +344,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 YBTable table = tableIdToTable.get(tableUUID);
 
                 String tabletId = tableIdToTabletId.getValue();
-                YBPartition part = new YBPartition(tableUUID, tabletId, table.isColocated());
+                YBPartition part = new YBPartition(tableUUID, tabletId, true /* colocated */);
                 
                  // Check if snapshot is completed here, if it is, then break out of the loop
                 if (snapshotCompletedTablets.size() == tableToTabletForSnapshot.size()) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -121,6 +121,10 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
         try {
             snapshotProgressListener.snapshotStarted(partition);
             Set<YBPartition> partitions = new YBPartition.Provider(connectorConfig).getPartitions();
+            LOGGER.info("Partitions received in getPartitions:");
+            for (YBPartition ppp : partitions) {
+              LOGGER.info(ppp.toString());
+            }
 
             // For snapshot, set all partitions to use tableID as identifier.
             partitions.forEach(YBPartition::markTableAsColocated);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -287,7 +287,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
       Set<String> snapshotCompletedPreviously = new HashSet<>();
 
       for (Pair<String, String> entry : tableToTabletIds) {
-        YBPartition p = new YBPartition(entry.getKey(), entry.getValue(), tableIdToTable.get(entry.getKey()).isColocated());
+        // We can use tableIdToTable.get(entry.getKey()).isColocated() to get actual status.
+        YBPartition p = new YBPartition(entry.getKey(), entry.getValue(), true /* colocated */);
         schemaNeeded.put(p.getId(), Boolean.TRUE);
         previousOffset.initSourceInfo(p, this.connectorConfig, YugabyteDBOffsetContext.snapshotStartLsn());
         LOGGER.debug("Previous offset for tablet {} is {}", entry.getValue(), previousOffset.toString());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -275,7 +275,7 @@ public class YugabyteDBStreamingChangeEventSource implements
 
             // For streaming, we do not want any colocated information and want to process the tables
             // based on just their tablet IDs - pass false as the 'colocated' flag to enforce the same.
-            YBPartition p = new YBPartition(entry.getKey(), entry.getValue(), tableIdToTable.get(entry.getKey()).isColocated());
+            YBPartition p = new YBPartition(entry.getKey(), entry.getValue(), false /* colocated */);
             offsetContext.initSourceInfo(p, this.connectorConfig, opId);
             schemaNeeded.put(p.getId(), Boolean.TRUE);
         }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -224,8 +224,6 @@ public class YugabyteDBStreamingChangeEventSource implements
                              YugabyteDBOffsetContext offsetContext,
                              boolean previousOffsetPresent)
             throws Exception {
-//        LOGGER.debug("The offset is " + offsetContext.getOffset());
-
         LOGGER.info("Processing messages");
 
         String tabletList = this.connectorConfig.getConfig().getString(YugabyteDBConnectorConfig.TABLET_LIST);
@@ -691,7 +689,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                 // TODO: The transaction_id field is getting populated somewhere and see if it can
                 // be removed or blocked from getting added to this map.
                 if (!entry.getKey().equals("transaction_id")) {
-                    LOGGER.debug("Tablet: {} OpId: {}", entry.getKey(), entry.getValue());
+                    LOGGER.info("Tablet: {} OpId: {}", entry.getKey(), entry.getValue());
 
                     // Parse the string to get the OpId object.
                     OpId tempOpId = OpId.valueOf((String) entry.getValue());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -358,7 +358,9 @@ public class YugabyteDBStreamingChangeEventSource implements
                         LOGGER.debug("Requesting schema for tablet: {}", tabletId);
                       }
 
-                      LOGGER.info("VKVK explicit cp for {} is {}.{}", part.getTabletId(), tabletToExplicitCheckpoint.get(part.getTabletId()).getTerm(), tabletToExplicitCheckpoint.get(part.getTabletId()).getIndex());
+                      if (tabletToExplicitCheckpoint.get(part.getTabletId()) != null) {
+                          LOGGER.info("VKVK explicit cp for {} is {}.{}", part.getTabletId(), tabletToExplicitCheckpoint.get(part.getTabletId()).getTerm(), tabletToExplicitCheckpoint.get(part.getTabletId()).getIndex());
+                      }
 
                       try {
                         response = this.syncClient.getChangesCDCSDK(

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -132,9 +132,6 @@ public class YugabyteDBStreamingChangeEventSource implements
 
         LOGGER.info("Starting the change streaming process now");
 
-        // For streaming, all the tables should be treated as non-colocated.
-        partitions.forEach(YBPartition::markTableAsColocated);
-
         if (!hasStartLsnStoredInContext) {
             LOGGER.info("No start opid found in the context.");
                 offsetContext = YugabyteDBOffsetContext.initialContext(connectorConfig, connection, clock, partitions);

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -224,7 +224,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                              YugabyteDBOffsetContext offsetContext,
                              boolean previousOffsetPresent)
             throws Exception {
-        LOGGER.debug("The offset is " + offsetContext.getOffset());
+//        LOGGER.debug("The offset is " + offsetContext.getOffset());
 
         LOGGER.info("Processing messages");
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -482,7 +482,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                             + " the table is " + message.getTable());
 
                                     // If a DDL message is received for a tablet, we do not need its schema again
-                                    schemaNeeded.put(entry.getKey() + "." + tabletId, Boolean.FALSE);
+                                    schemaNeeded.put(part.getId(), Boolean.FALSE);
 
                                     TableId tableId = null;
                                     if (message.getOperation() != Operation.NOOP) {

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -358,11 +358,13 @@ public class YugabyteDBStreamingChangeEventSource implements
                         LOGGER.debug("Requesting schema for tablet: {}", tabletId);
                       }
 
+                      LOGGER.info("VKVK explicit cp for {} is {}.{}", part.getTabletId(), tabletToExplicitCheckpoint.get(part.getTabletId()).getTerm(), tabletToExplicitCheckpoint.get(part.getTabletId()).getIndex());
+
                       try {
                         response = this.syncClient.getChangesCDCSDK(
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
                             cp.getWrite_id(), cp.getTime(), schemaNeeded.get(entry.getKey() + "." + tabletId),
-                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(entry.getKey() + "." + tabletId) : null);
+                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getTabletId()) : null);
                       } catch (CDCErrorException cdcException) {
                         // Check if exception indicates a tablet split.
                         LOGGER.debug("Code received in CDCErrorException: {}", cdcException.getCDCError().getCode());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -622,7 +622,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                final OpId lsn)
             throws SQLException, InterruptedException {
         lastCompletelyProcessedLsn = lsn;
-        offsetContext.updateCommitPosition(lsn, lastCompletelyProcessedLsn);
+        offsetContext.updateCommitPosition(partition.getTableId(), partition.getTabletId(), lsn, lastCompletelyProcessedLsn);
         maybeWarnAboutGrowingWalBacklog(false);
         dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -358,10 +358,6 @@ public class YugabyteDBStreamingChangeEventSource implements
                         LOGGER.debug("Requesting schema for tablet: {}", tabletId);
                       }
 
-                      if (tabletToExplicitCheckpoint.get(part.getTabletId()) != null) {
-                          LOGGER.info("VKVK explicit cp for {} is {}.{}", part.getTabletId(), tabletToExplicitCheckpoint.get(part.getTabletId()).getTerm(), tabletToExplicitCheckpoint.get(part.getTabletId()).getIndex());
-                      }
-
                       try {
                         response = this.syncClient.getChangesCDCSDK(
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
@@ -693,7 +689,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                 // TODO: The transaction_id field is getting populated somewhere and see if it can
                 // be removed or blocked from getting added to this map.
                 if (!entry.getKey().equals("transaction_id")) {
-                    LOGGER.info("Tablet: {} OpId: {}", entry.getKey(), entry.getValue());
+                    LOGGER.debug("Tablet: {} OpId: {}", entry.getKey(), entry.getValue());
 
                     // Parse the string to get the OpId object.
                     OpId tempOpId = OpId.valueOf((String) entry.getValue());

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -275,9 +275,9 @@ public class YugabyteDBStreamingChangeEventSource implements
 
             // For streaming, we do not want any colocated information and want to process the tables
             // based on just their tablet IDs - pass false as the 'colocated' flag to enforce the same.
-            offsetContext.initSourceInfo(entry.getKey(), entry.getValue(), this.connectorConfig, opId,
-                                         false /* colocated */);
-            schemaNeeded.put(entry.getKey() + "." + entry.getValue(), Boolean.TRUE);
+            YBPartition p = new YBPartition(entry.getKey(), entry.getValue(), tableIdToTable.get(entry.getKey()).isColocated());
+            offsetContext.initSourceInfo(p, this.connectorConfig, opId);
+            schemaNeeded.put(p.getId(), Boolean.TRUE);
         }
 
         // This will contain the tablet ID mapped to the number of records it has seen
@@ -335,7 +335,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                         curTabletId = entry.getValue();
                         YBPartition part = new YBPartition(entry.getKey() /* tableId */, tabletId, false /* colocated */);
 
-                      OpId cp = offsetContext.lsn(entry.getKey() /* tableUUID */, tabletId);
+                      OpId cp = offsetContext.lsn(part);
 
                       YBTable table = tableIdToTable.get(entry.getKey());
 
@@ -354,15 +354,15 @@ public class YugabyteDBStreamingChangeEventSource implements
 
                       GetChangesResponse response = null;
 
-                      if (schemaNeeded.get(entry.getKey() + "." + tabletId)) {
+                      if (schemaNeeded.get(part.getId())) {
                         LOGGER.debug("Requesting schema for tablet: {}", tabletId);
                       }
 
                       try {
                         response = this.syncClient.getChangesCDCSDK(
                             table, streamId, tabletId, cp.getTerm(), cp.getIndex(), cp.getKey(),
-                            cp.getWrite_id(), cp.getTime(), schemaNeeded.get(entry.getKey() + "." + tabletId),
-                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getTabletId()) : null);
+                            cp.getWrite_id(), cp.getTime(), schemaNeeded.get(part.getId()),
+                            taskContext.shouldEnableExplicitCheckpointing() ? tabletToExplicitCheckpoint.get(part.getId()) : null);
                       } catch (CDCErrorException cdcException) {
                         // Check if exception indicates a tablet split.
                         LOGGER.debug("Code received in CDCErrorException: {}", cdcException.getCDCError().getCode());
@@ -419,62 +419,61 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         if (message.getOperation() == Operation.BEGIN) {
                                             LOGGER.debug("LSN in case of BEGIN is " + lsn);
 
-                                            recordsInTransactionalBlock.put(entry.getKey() + "." + tabletId, 0);
-                                            beginCountForTablet.merge(entry.getKey() + "." + tabletId, 1, Integer::sum);
+                                            recordsInTransactionalBlock.put(part.getId(), 0);
+                                            beginCountForTablet.merge(part.getId(), 1, Integer::sum);
                                         }
                                         if (message.getOperation() == Operation.COMMIT) {
                                             LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                                            offsetContext.updateWalPosition(entry.getKey(), tabletId, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
+                                            offsetContext.updateWalPosition(part, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
                                                     String.valueOf(message.getTransactionId()), null, null/* taskContext.getSlotXmin(connection) */);
                                             commitMessage(part, offsetContext, lsn);
 
-                                            if (recordsInTransactionalBlock.containsKey(entry.getKey() + "." + tabletId)) {
-                                                if (recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId) == 0) {
+                                            if (recordsInTransactionalBlock.containsKey(part.getId())) {
+                                                if (recordsInTransactionalBlock.get(part.getId()) == 0) {
                                                     LOGGER.debug("Records in the transactional block of transaction: {}, with LSN: {}, for tablet {} are 0",
-                                                                message.getTransactionId(), lsn, entry.getKey() + "." + tabletId);
+                                                                message.getTransactionId(), lsn, part.getId());
                                                 } else {
                                                     LOGGER.debug("Records in the transactional block transaction: {}, with LSN: {}, for tablet {}: {}",
-                                                                 message.getTransactionId(), lsn, entry.getKey() + "." + tabletId, recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId));
+                                                                 message.getTransactionId(), lsn, part.getId(), recordsInTransactionalBlock.get(part.getId()));
                                                 }
-                                            } else if (beginCountForTablet.get(entry.getKey() + "." + tabletId).intValue() == 0) {
+                                            } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
                                                 throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
                                             }
 
-                                            recordsInTransactionalBlock.remove(entry.getKey() + "." + tabletId);
-                                            beginCountForTablet.merge(entry.getKey() + "." + tabletId, -1, Integer::sum);
+                                            recordsInTransactionalBlock.remove(part.getId());
+                                            beginCountForTablet.merge(part.getId(), -1, Integer::sum);
                                         }
                                         continue;
                                     }
 
                                     if (message.getOperation() == Operation.BEGIN) {
                                         LOGGER.debug("LSN in case of BEGIN is " + lsn);
-                                        dispatcher.dispatchTransactionStartedEvent(part,
-                                                message.getTransactionId(), offsetContext);
+                                        dispatcher.dispatchTransactionStartedEvent(part, message.getTransactionId(), offsetContext);
 
-                                        recordsInTransactionalBlock.put(entry.getKey() + "." + tabletId, 0);
-                                        beginCountForTablet.merge(entry.getKey() + "." + tabletId, 1, Integer::sum);
+                                        recordsInTransactionalBlock.put(part.getId(), 0);
+                                        beginCountForTablet.merge(part.getId(), 1, Integer::sum);
                                     }
                                     else if (message.getOperation() == Operation.COMMIT) {
                                         LOGGER.debug("LSN in case of COMMIT is " + lsn);
-                                        offsetContext.updateWalPosition(entry.getKey(), tabletId, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
+                                        offsetContext.updateWalPosition(part, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
                                                 String.valueOf(message.getTransactionId()), null, null/* taskContext.getSlotXmin(connection) */);
                                         commitMessage(part, offsetContext, lsn);
                                         dispatcher.dispatchTransactionCommittedEvent(part, offsetContext);
 
-                                        if (recordsInTransactionalBlock.containsKey(entry.getKey() + "." + tabletId)) {
-                                            if (recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId) == 0) {
+                                        if (recordsInTransactionalBlock.containsKey(part.getId())) {
+                                            if (recordsInTransactionalBlock.get(part.getId()) == 0) {
                                                 LOGGER.debug("Records in the transactional block of transaction: {}, with LSN: {}, for tablet {} are 0",
-                                                            message.getTransactionId(), lsn, entry.getKey() + "." + tabletId);
+                                                            message.getTransactionId(), lsn, part.getId());
                                             } else {
                                                 LOGGER.debug("Records in the transactional block transaction: {}, with LSN: {}, for tablet {}: {}",
-                                                             message.getTransactionId(), lsn, entry.getKey() + "." + tabletId, recordsInTransactionalBlock.get(entry.getKey() + "." + tabletId));
+                                                             message.getTransactionId(), lsn, part.getId(), recordsInTransactionalBlock.get(part.getId()));
                                             }
-                                        } else if (beginCountForTablet.get(entry.getKey() + "." + tabletId).intValue() == 0) {
+                                        } else if (beginCountForTablet.get(part.getId()).intValue() == 0) {
                                             throw new DebeziumException("COMMIT record encountered without a preceding BEGIN record");
                                         }
 
-                                        recordsInTransactionalBlock.remove(entry.getKey() + "." + tabletId);
-                                        beginCountForTablet.merge(entry.getKey() + "." + tabletId, -1, Integer::sum);
+                                        recordsInTransactionalBlock.remove(part.getId());
+                                        beginCountForTablet.merge(part.getId(), -1, Integer::sum);
                                     }
                                     maybeWarnAboutGrowingWalBacklog(true);
                                 }
@@ -513,12 +512,12 @@ public class YugabyteDBStreamingChangeEventSource implements
                                     // If you need to print the received record, change debug level to info
                                     LOGGER.debug("Received DML record {}", record);
 
-                                    offsetContext.updateWalPosition(entry.getKey(), tabletId, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
+                                    offsetContext.updateWalPosition(part, lsn, lastCompletelyProcessedLsn, message.getCommitTime(),
                                             String.valueOf(message.getTransactionId()), tableId, null/* taskContext.getSlotXmin(connection) */);
 
                                     boolean dispatched = message.getOperation() != Operation.NOOP
                                             && dispatcher.dispatchDataChangeEvent(part, tableId, new YugabyteDBChangeRecordEmitter(part, offsetContext, clock, connectorConfig,
-                                                    schema, connection, tableId, message, pgSchemaNameInRecord, entry.getKey() /* tableUUID */, tabletId, taskContext.isBeforeImageEnabled()));
+                                                    schema, connection, tableId, message, pgSchemaNameInRecord, tabletId, taskContext.isBeforeImageEnabled()));
 
                                     if (recordsInTransactionalBlock.containsKey(entry.getKey() + "." + tabletId)) {
                                         recordsInTransactionalBlock.merge(entry.getKey() + "." + tabletId, 1, Integer::sum);
@@ -547,8 +546,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 response.getKey(),
                                 response.getWriteId(),
                                 response.getSnapshotTime());
-                        offsetContext.getSourceInfo(entry.getKey() /* tableId */, tabletId)
-                                .updateLastCommit(finalOpid);
+                        offsetContext.getSourceInfo(part).updateLastCommit(finalOpid);
 
                         LOGGER.debug("The final opid is " + finalOpid);
                     }
@@ -773,16 +771,18 @@ public class YugabyteDBStreamingChangeEventSource implements
                                        YugabyteDBOffsetContext offsetContext,
                                        Map<String, Boolean> schemaNeeded) {
         String tabletId = pair.getTabletLocations().getTabletId().toStringUtf8();
-        ImmutablePair<String, String> p =
+        ImmutablePair<String, String> tableTabletPair =
           new ImmutablePair<String, String>(tableId, tabletId);
 
-        if (!tabletPairList.contains(p)) {
-            tabletPairList.add(p);
+        if (!tabletPairList.contains(tableTabletPair)) {
+            tabletPairList.add(tableTabletPair);
 
-            offsetContext.initSourceInfo(tableId, tabletId,
-                                         this.connectorConfig,
-                                         OpId.from(pair.getCdcSdkCheckpoint()),
-                                         false /* colocated */);
+            // This flow will be executed in case of tablet split only and since tablet split
+            // is not possible on colocated tables, it is safe to assume that the tablets here
+            // would be all non-colocated.
+            YBPartition p = new YBPartition(tableId, tabletId, false /* colocated */);
+            offsetContext.initSourceInfo(p, this.connectorConfig,
+                                         OpId.from(pair.getCdcSdkCheckpoint()));
 
             LOGGER.info("Initialized offset context for tablet {} with OpId {}", tabletId, OpId.from(pair.getCdcSdkCheckpoint()));
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -622,7 +622,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                final OpId lsn)
             throws SQLException, InterruptedException {
         lastCompletelyProcessedLsn = lsn;
-        offsetContext.updateCommitPosition(partition.getTableId(), partition.getTabletId(), lsn, lastCompletelyProcessedLsn);
+        offsetContext.updateCommitPosition(lsn, lastCompletelyProcessedLsn);
         maybeWarnAboutGrowingWalBacklog(false);
         dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -338,7 +338,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                     for (Pair<String, String> entry : tabletPairList) {
                         final String tabletId = entry.getValue();
                         curTabletId = entry.getValue();
-                        YBPartition part = new YBPartition(entry.getKey() /* tableId */, tabletId);
+                        YBPartition part = new YBPartition(entry.getKey() /* tableId */, tabletId, false /* colocated */);
 
                       OpId cp = offsetContext.lsn(entry.getKey() /* tableUUID */, tabletId);
 

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
@@ -113,7 +113,7 @@ public class YugabyteDBMetrics {
           mBeanServer.registerMBean(this, name);
           break;
         } catch (InstanceAlreadyExistsException e) {
-          LOGGER.info("Metric name: {}", name);
+          LOGGER.info("Metric name: {} and existing message", name, e);
           if (attempt < REGISTRATION_RETRIES) {
             LOGGER.warn(
               "Unable to register metrics as an old set with the same name exists, retrying in {} (attempt {} out of {})",

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
@@ -113,6 +113,7 @@ public class YugabyteDBMetrics {
           mBeanServer.registerMBean(this, name);
           break;
         } catch (InstanceAlreadyExistsException e) {
+          LOGGER.info("Metric name: {}", name);
           if (attempt < REGISTRATION_RETRIES) {
             LOGGER.warn(
               "Unable to register metrics as an old set with the same name exists, retrying in {} (attempt {} out of {})",

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBMetrics.java
@@ -113,7 +113,6 @@ public class YugabyteDBMetrics {
           mBeanServer.registerMBean(this, name);
           break;
         } catch (InstanceAlreadyExistsException e) {
-          LOGGER.info("Metric name: {} and existing message", name, e);
           if (attempt < REGISTRATION_RETRIES) {
             LOGGER.warn(
               "Unable to register metrics as an old set with the same name exists, retrying in {} (attempt {} out of {})",

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
@@ -34,7 +34,7 @@ public class YugabyteDBSnapshotTaskMetrics extends AbstractYugabyteDBTaskMetrics
                                 "server", taskContext.getConnectorName(),
                                 "task", taskId,
                                 "context", "snapshot",
-                                "partition", partition.getTableId() + "." + partition.getTabletId()),
+                                "partition", partition.getFullPartitionName()),
                         metadataProvider), connectorConfig, taskId);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBSnapshotTaskMetrics.java
@@ -34,7 +34,7 @@ public class YugabyteDBSnapshotTaskMetrics extends AbstractYugabyteDBTaskMetrics
                                 "server", taskContext.getConnectorName(),
                                 "task", taskId,
                                 "context", "snapshot",
-                                "partition", partition.getId()),
+                                "partition", partition.getTableId() + "." + partition.getTabletId()),
                         metadataProvider), connectorConfig, taskId);
     }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
@@ -36,7 +36,7 @@ public class YugabyteDBStreamingTaskMetrics extends AbstractYugabyteDBTaskMetric
                         "server", taskContext.getConnectorName(),
                         "task", taskId,
                         "context", "streaming",
-                        "partition", partition.getId()),
+                        "partition", partition.getTableId() + "." + partition.getTabletId()),
                     metadataProvider), connectorConfig, taskId);
         connectionMeter = new ConnectionMeter();
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/metrics/YugabyteDBStreamingTaskMetrics.java
@@ -36,7 +36,7 @@ public class YugabyteDBStreamingTaskMetrics extends AbstractYugabyteDBTaskMetric
                         "server", taskContext.getConnectorName(),
                         "task", taskId,
                         "context", "streaming",
-                        "partition", partition.getTableId() + "." + partition.getTabletId()),
+                        "partition", partition.getFullPartitionName()),
                     metadataProvider), connectorConfig, taskId);
         connectionMeter = new ConnectionMeter();
     }

--- a/src/main/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtils.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtils.java
@@ -1,0 +1,113 @@
+package io.debezium.connector.yugabytedb.util;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Utility functions to assist across various stages of flow in the connector.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YugabyteDBConnectorUtils {
+	public static <T> void groupPartitions(List<T> elements, int numGroups, List<List<T>> result) {
+		if (numGroups <= 0)
+			throw new IllegalArgumentException("Number of groups must be positive.");
+
+		List<List<T>> res = new ArrayList<>(numGroups);
+
+		// Each group has either n+1 or n raw partitions
+		int perGroup = elements.size() / numGroups;
+		int leftover = elements.size() - (numGroups * perGroup);
+
+		int assigned = 0;
+		for (int group = 0; group < numGroups; group++) {
+			if (assigned == elements.size()) {
+				// We need not assign empty groups if we have exhausted the total number of elements.
+				break;
+			}
+			int numThisGroup = group < leftover ? perGroup + 1 : perGroup;
+			List<T> groupList = new ArrayList<>(numThisGroup);
+			for (int i = 0; i < numThisGroup; i++) {
+				groupList.add(elements.get(assigned));
+				assigned++;
+			}
+			res.add(groupList);
+		}
+
+		result.addAll(res);
+	}
+
+	/**
+	 * This grouping function ensures that we group the tablets in a way that each task contains
+	 * all the tables of just one colocated tablet. For non-colocated tables, the division of tablets
+	 * will be done the regular way.
+	 * @param elements a list of pairs where key is tableId and value is tabletId
+	 * @param numGroups the total number of groups we should be dividing the tasks to.
+	 */
+	public static List<List<Pair<String, String>>> groupPartitionsSmartly(
+			List<Pair<String, String>> elements, int numGroups) {
+		if (elements.size() == 0) {
+			throw new IllegalStateException("Elements to be grouped must be positive");
+		}
+
+		if (numGroups <= 0) {
+			throw new IllegalArgumentException("Number of groups must be positive");
+		}
+
+		List<List<Pair<String, String>>> result = new ArrayList<>(numGroups);
+
+		// Filter out groups having the same tabletId as value
+		// The map will have tabletId -> table1,table2,table3 map
+		Map<String, ArrayList<String>> reverseMap = new HashMap<>(
+			elements.stream().collect(Collectors.groupingBy(Pair::getValue)).values().stream()
+				.collect(Collectors.toMap(
+					item -> item.get(0).getValue(),
+					item -> new ArrayList<>(
+						item.stream()
+							.map(Map.Entry::getKey)
+							.collect(Collectors.toList())
+					))
+				));
+
+		// If there are same number of tablets in the grouped reverse map then use the older function
+		// to group rather than going to the complicated logic of grouping colocated and non-colocated
+		// tablets differently.
+		// Note: The keySet of the reverse map will only contain tablets.
+		if (reverseMap.keySet().size() == elements.size()) {
+			groupPartitions(elements, numGroups, result);
+			return result;
+		}
+
+		// Divide tablets into tasks and then form groups based on that.
+		List<List<String>> groupedTablets = new ArrayList<>();
+		groupPartitions(new ArrayList<>(reverseMap.keySet()), numGroups, groupedTablets);
+
+		// Iterate over grouped tablets now.
+		// The assumption here is that at this stage, the division of tablets across tasks would be
+		// something similar to:
+		// 1. Task 1 -
+		//    a. tablet_1
+		//    b. tablet_2
+		//    b. tablet_3
+		// 2. Task 2 -
+		//    a. tablet_4
+		//    b. tablet_5
+		// After this, we can simply iterate over the reversed map and just put proper table-tablet
+		// pairs to the task list.
+		for (List<String> tablets : groupedTablets) {
+			List<Pair<String, String>> groupList = new ArrayList<>();
+			for (String tablet : tablets) {
+				for (String table : reverseMap.get(tablet)) {
+					groupList.add(new ImmutablePair<>(table, tablet));
+				}
+			}
+
+			result.add(groupList);
+		}
+
+		return result;
+	}
+}

--- a/src/test/java/io/debezium/connector/yugabytedb/HelperStrings.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/HelperStrings.java
@@ -1,6 +1,10 @@
 package io.debezium.connector.yugabytedb;
 
 public class HelperStrings {
+    public static String CREATE_ALL_TYPES = "CREATE TABLE all_types (id serial PRIMARY KEY, bigintcol bigint, bitcol bit(5), varbitcol varbit(5), booleanval boolean, byteaval bytea, ch char(5), vchar varchar(25), " +
+                                             "cidrval cidr, dt date, dp double precision, inetval inet, intervalval interval, jsonval json, jsonbval jsonb, mc macaddr, mc8 macaddr8, mn money, nm numeric, rl real, " +
+                                             "si smallint, i4r int4range, i8r int8range, nr numrange, tsr tsrange, tstzr tstzrange, dr daterange, txt text, tm time, tmtz timetz, ts timestamp, tstz timestamptz, " +
+                                             "uuidval uuid) WITH (COLOCATION = false);";
     public static String INSERT_ALL_TYPES = "INSERT INTO all_types (bigintcol, bitcol, varbitcol, booleanval, byteaval, ch, vchar, cidrval, dt, dp, inetval, "
             + "intervalval, jsonval, jsonbval, mc, mc8, mn, nm, rl, si, i4r, i8r, nr, tsr, tstzr, dr, txt, tm, tmtz, ts, tstz, uuidval) VALUES "
             + "(123456, '11011', '10101', FALSE, E'\\\\001', 'five5', 'sample_text', '10.1.0.0/16', '2022-02-24', 12.345, '127.0.0.1', "

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBExplicitCheckpointingTest.java
@@ -117,7 +117,11 @@ public class YugabyteDBExplicitCheckpointingTest extends YugabyteDBContainerTest
         YBClient ybClient = TestHelper.getYbClient(getMasterAddress());
         for (Map.Entry<String, ?> entry : offsetMap.entrySet()) {
             if (!entry.getKey().equals("transaction_id")) {
-                String tabletId = entry.getKey().split(Pattern.quote("."))[1];
+                String[] splitString = entry.getKey().split(Pattern.quote("."));
+
+                // If string doesn't split, that means we have only received the tabletId in the
+                // response, if it splits then we will have two elements - tableId and tabletId.
+                String tabletId = splitString.length == 1 ? splitString[0] : splitString[1];
                 CdcSdkCheckpoint cp = OpId.valueOf((String) entry.getValue()).toCdcSdkCheckpoint();
 
                 GetCheckpointResponse resp = ybClient.getCheckpoint(

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -142,7 +142,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         TestHelper.executeInDatabase(
           String.format(insertStringFormat,
             String.format("generate_series(%d, %d)",
-              recordCountT1, recordCountT1 + 1001)), DEFAULT_COLOCATED_DB_NAME);
+              recordCountT1, recordCountT1 + 1000)), DEFAULT_COLOCATED_DB_NAME);
 
         // Total records inserted at this stage would be recordCountT1 + 1001
         int totalRecords = recordCountT1 + 1001;

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -83,7 +83,6 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         TestHelper.dropAllSchemas();
         createTables(colocation);
 
-
         int recordCountT1 = 5000;
 
         // Insert records in the table test_1
@@ -374,6 +373,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_2;", DEFAULT_COLOCATED_DB_NAME);
         TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_3;", DEFAULT_COLOCATED_DB_NAME);
         TestHelper.executeInDatabase("DROP TABLE IF EXISTS test_no_colocated;", DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase("DROP TABLE IF EXISTS all_types;", DEFAULT_COLOCATED_DB_NAME);
     }
 
     private void insertBulkRecords(int numRecords, String fullTableName) {

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -413,7 +413,7 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
                       LOGGER.info("Consumed " + totalConsumedRecords + " records");
                   }
 
-                  return totalConsumedRecords.get() >= recordsCount;
+                  return totalConsumedRecords.get() == recordsCount;
               });
         } catch (ConditionTimeoutException exception) {
             fail("Failed to consume " + recordsCount + " in " + seconds + " seconds", exception);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -142,10 +142,10 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         TestHelper.executeInDatabase(
           String.format(insertStringFormat,
             String.format("generate_series(%d, %d)",
-              recordCountT1, recordCountT1 + 1000)), DEFAULT_COLOCATED_DB_NAME);
+              recordCountT1, recordCountT1 + 1001)), DEFAULT_COLOCATED_DB_NAME);
 
-        // Total records inserted at this stage would be recordCountT1 + 1000
-        int totalRecords = recordCountT1 + 1000;
+        // Total records inserted at this stage would be recordCountT1 + 1001
+        int totalRecords = recordCountT1 + 1001;
 
         // Consume and assert that we have received all the records now.
         List<SourceRecord> records = new ArrayList<>();

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -89,8 +89,8 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         insertBulkRecords(recordCountT1, "public.test_1");
 
         // Insert records in the table all_types
-        TestHelper.executeInDatabase(DEFAULT_COLOCATED_DB_NAME, HelperStrings.INSERT_ALL_TYPES);
-        TestHelper.executeInDatabase(DEFAULT_COLOCATED_DB_NAME, HelperStrings.INSERT_ALL_TYPES);
+        TestHelper.executeInDatabase(HelperStrings.INSERT_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
+        TestHelper.executeInDatabase(HelperStrings.INSERT_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
 
         String dbStreamId = TestHelper.getNewDbStreamId(DEFAULT_COLOCATED_DB_NAME, "test_1");
         Configuration.Builder configBuilder = TestHelper.getConfigBuilder(DEFAULT_COLOCATED_DB_NAME, "public.test_1,public.all_types", dbStreamId);

--- a/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotTest.java
@@ -83,12 +83,14 @@ public class YugabyteDBSnapshotTest extends YugabyteDBContainerTestBase {
         TestHelper.dropAllSchemas();
         createTables(colocation);
 
+
         int recordCountT1 = 5000;
 
         // Insert records in the table test_1
         insertBulkRecords(recordCountT1, "public.test_1");
 
-        // Insert records in the table all_types
+        // Create table and insert records in all_types
+        TestHelper.executeInDatabase(HelperStrings.CREATE_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
         TestHelper.executeInDatabase(HelperStrings.INSERT_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
         TestHelper.executeInDatabase(HelperStrings.INSERT_ALL_TYPES, DEFAULT_COLOCATED_DB_NAME);
 

--- a/src/test/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtilsTest.java
+++ b/src/test/java/io/debezium/connector/yugabytedb/util/YugabyteDBConnectorUtilsTest.java
@@ -1,0 +1,180 @@
+package io.debezium.connector.yugabytedb.util;
+
+import io.debezium.connector.yugabytedb.common.YugabyteDBContainerTestBase;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests to verify the behaviour of various APIs the connector is supposed to use
+ * in order to make sure those APIs are working fine as an individual unit. This test class will
+ * always remain a work in progress.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YugabyteDBConnectorUtilsTest extends YugabyteDBContainerTestBase {
+	@Test
+	public void allColocatedTablesBelongToSameTablet() throws Exception {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "same_tablet");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "same_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+
+		// A random number of groups.
+		final int numberGroups = 2;
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+
+		// Since all the tablets are the same, we should be getting only 1 batch i.e. the size of
+		// grouped tablets would be 1.
+		assertEquals(1, groupedTablets.size());
+	}
+
+	@ParameterizedTest(name = "Equal tablets as groups: {0}")
+	@ValueSource(booleans = {true, false})
+	public void someTablesBelongToDifferentTablet(boolean equalTabletsAsGroups) {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "same_tablet");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "different_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+
+		final int numGroups = equalTabletsAsGroups ? 2 : 1;
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numGroups);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(numGroups, groupedTablets.size());
+	}
+
+	@ParameterizedTest(name = "All tablets to one group: {0}")
+	@ValueSource(booleans = {true, false})
+	public void higherTabletsLowerGroups(boolean allTabletsToOneGroup) {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "tablet_1");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "tablet_1");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "tablet_2");
+		Pair<String, String> pair4 = new ImmutablePair<>("table4", "tablet_2");
+		Pair<String, String> pair5 = new ImmutablePair<>("table5", "tablet_3");
+		Pair<String, String> pair6 = new ImmutablePair<>("table6", "tablet_3");
+		Pair<String, String> pair7 = new ImmutablePair<>("table7", "tablet_4");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+		pairList.add(pair4);
+		pairList.add(pair5);
+		pairList.add(pair6);
+		pairList.add(pair7);
+
+		final int numGroups = allTabletsToOneGroup ? 1 : 2;
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numGroups);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(numGroups, groupedTablets.size());
+	}
+
+	@Test
+	public void multipleColocatedTabletsPresent() {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "same_tablet");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "different_tablet");
+		Pair<String, String> pair4 = new ImmutablePair<>("table4", "different_tablet");
+		Pair<String, String> pair5 = new ImmutablePair<>("table5", "different_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+		pairList.add(pair4);
+		pairList.add(pair5);
+
+		// A random number of groups.
+		final int numberGroups = 5;
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(2, groupedTablets.size());
+	}
+
+	@Test
+	public void throwExceptionOnInvalidGroupSize() {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "same_tablet");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+
+		// 0 is an invalid group size.
+		final int numberGroups = 0;
+
+		try {
+			List<List<Pair<String, String>>> groupedTablets =
+				YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+		} catch (Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertTrue(e.getMessage().contains("Number of groups must be positive"));
+		}
+	}
+
+	@Test
+	public void throwExceptionOnEmptyList() {
+		List<Pair<String, String>> pairList = new ArrayList<>();
+
+		// 0 is an invalid group size.
+		final int numberGroups = 1;
+
+		try {
+			List<List<Pair<String, String>>> groupedTablets =
+				YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, numberGroups);
+		} catch (Exception e) {
+			assertTrue(e instanceof IllegalStateException);
+			assertTrue(e.getMessage().contains("Elements to be grouped must be positive"));
+		}
+	}
+
+	@ParameterizedTest(name = "{0} tasks")
+	@ValueSource(ints = {1, 2, 3, 4, 5})
+	public void allNonColocatedTablets(int maxTasks) {
+		Pair<String, String> pair1 = new ImmutablePair<>("table1", "tablet1");
+		Pair<String, String> pair2 = new ImmutablePair<>("table2", "tablet2");
+		Pair<String, String> pair3 = new ImmutablePair<>("table3", "tablet3");
+		Pair<String, String> pair4 = new ImmutablePair<>("table4", "tablet4");
+		Pair<String, String> pair5 = new ImmutablePair<>("table5", "tablet5");
+
+		List<Pair<String, String>> pairList = new ArrayList<>();
+		pairList.add(pair1);
+		pairList.add(pair2);
+		pairList.add(pair3);
+		pairList.add(pair4);
+		pairList.add(pair5);
+
+		List<List<Pair<String, String>>> groupedTablets =
+			YugabyteDBConnectorUtils.groupPartitionsSmartly(pairList, maxTasks);
+
+		// Since all the tablets are NOT the same, we should be getting only 2 batches
+		// i.e. the size of grouped tablets would be 2.
+		assertEquals(maxTasks, groupedTablets.size());
+	}
+}

--- a/src/test/resources/yugabyte_create_tables.ddl
+++ b/src/test/resources/yugabyte_create_tables.ddl
@@ -3,7 +3,7 @@ CREATE TABLE t1 (id INT PRIMARY KEY, first_name TEXT NOT NULL, last_name VARCHAR
 CREATE TABLE all_types (id serial PRIMARY KEY, bigintcol bigint, bitcol bit(5), varbitcol varbit(5), booleanval boolean, byteaval bytea, ch char(5), vchar varchar(25),
 cidrval cidr, dt date, dp double precision, inetval inet, intervalval interval, jsonval json, jsonbval jsonb, mc macaddr, mc8 macaddr8, mn money, nm numeric, rl real,
 si smallint, i4r int4range, i8r int8range, nr numrange, tsr tsrange, tstzr tstzrange, dr daterange, txt text, tm time, tmtz timetz, ts timestamp, tstz timestamptz,
-uuidval uuid);
+uuidval uuid) WITH (COLOCATION = false);
 
 DROP DATABASE IF EXISTS secondary_database;
 CREATE DATABASE secondary_database;


### PR DESCRIPTION
This PR merges the following things to the feature branch:
1. Grouping function to add all colocated tables in a single task only. Added UTs for the same function as well.
2. Ignore `tableId` while in streaming mode.
    a. As a part of this, we are forcefully calling all the tables in the streaming mode as non-colocated tables even if they are colocated tables.