### PR TITLE
Add structured MDC-based logging with tablet context across tablet operations

### DIFF
--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConsistentStreamingSource.java
@@ -147,6 +147,8 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                             final String tabletId = entry.getValue();
                             curTabletId = entry.getValue();
                             YBPartition part = new YBPartition(entry.getKey(), tabletId, false);
+                            YugabyteDBTaskContext.setTabletContext(entry.getKey(), tabletId);
+                            try {
 
                             OpId cp = offsetContext.lsn(part);
 
@@ -182,7 +184,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                 } catch (CDCErrorException cdcException) {
                                     // Check if exception indicates a tablet split.
                                     if (cdcException.getCDCError().getCode() == CdcService.CDCErrorPB.Code.TABLET_SPLIT) {
-                                        LOGGER.info("Encountered a tablet split, handling it gracefully");
+                                        LOGGER.info("Encountered a tablet split on tablet {}, handling it gracefully", tabletId);
                                         if (LOGGER.isDebugEnabled()) {
                                             cdcException.printStackTrace();
                                         }
@@ -196,8 +198,8 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                     }
                                 }
 
-                                LOGGER.debug("Processing {} records from getChanges call",
-                                        response.getResp().getCdcSdkProtoRecordsList().size());
+                                LOGGER.debug("Processing {} records from getChanges call for tablet {}",
+                                        response.getResp().getCdcSdkProtoRecordsList().size(), tabletId);
                                 for (CdcService.CDCSDKProtoRecordPB record : response
                                         .getResp()
                                         .getCdcSdkProtoRecordsList()) {
@@ -238,6 +240,9 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                                 // for the snapshot, this block must not commit during catch up streaming.
                                 // CDCSDK Find out why this fails : connection.commit();
                             }
+                            } finally {
+                                YugabyteDBTaskContext.clearTabletContext();
+                            }
                         }
 
                         Optional<Message> pollMessage = merger.poll();
@@ -259,7 +264,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                         retryCount = 0;
                     }
                 } catch (AssertionError ae) {
-                    LOGGER.error("Assertion error received: {}", ae);
+                    LOGGER.error("Assertion error received for tablet {}: {}", curTabletId, ae);
                     merger.dumpState();
 
                     // The connector should ideally be stopped if this kind of state is reached.
@@ -273,8 +278,8 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                     }
 
                     // If there are retries left, perform them after the specified delay.
-                    LOGGER.warn("Error while trying to get the changes from the server; will attempt retry {} of {} after {} milli-seconds. Exception: {}",
-                            retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e);
+                    LOGGER.warn("Error while trying to get the changes from the server for tablet {}; will attempt retry {} of {} after {} milli-seconds. Exception: {}",
+                            curTabletId, retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e);
                     LOGGER.warn("Stacktrace", e);
 
                     try {
@@ -428,7 +433,7 @@ public class YugabyteDBConsistentStreamingSource extends YugabyteDBStreamingChan
                 maybeWarnAboutGrowingWalBacklog(dispatched);
             }
         } catch (InterruptedException ie) {
-            LOGGER.error("Interrupted exception while processing change records", ie);
+            LOGGER.error("Interrupted exception while processing change records for tablet {}", tabletId, ie);
             Thread.currentThread().interrupt();
         }
 

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBSnapshotChangeEventSource.java
@@ -485,6 +485,8 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
 
                 String tabletId = tableIdToTabletId.getValue();
                 YBPartition part = new YBPartition(tableUUID, tabletId, true /* colocated */);
+                YugabyteDBTaskContext.setTabletContext(tableUUID, tabletId);
+                try {
 
                  // Check if snapshot is completed here, if it is, then break out of the loop
                 if (snapshotCompletedTablets.size() == tableToTabletForSnapshot.size()) {
@@ -586,7 +588,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                       // Ideally there shouldn't be any BEGIN-COMMIT record while streaming
                       // the snapshot, if one is encountered then log a warning so the user knows
                       // that some debugging is required
-                      LOGGER.warn("Transactional record of type {} encountered while snapshotting the table", message.getOperation().toString());
+                      LOGGER.warn("Transactional record of type {} encountered while snapshotting table {} tablet {}", message.getOperation().toString(), tableUUID, tabletId);
                     } else if (message.isDDLMessage()) {
                       LOGGER.debug("For table {}, received a DDL record {}",
                                   message.getTable(), message.getSchema().toString());
@@ -654,7 +656,7 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                       LOGGER.debug("Dispatched snapshot record successfully");
                     }
                   } catch (InterruptedException e) {
-                    LOGGER.error("Exception while processing messages for snapshot: " + e);
+                    LOGGER.error("Exception while processing messages for snapshot on table {} tablet {}", tableUUID, tabletId, e);
                     throw e;
                   }
                 }
@@ -734,8 +736,11 @@ public class YugabyteDBSnapshotChangeEventSource extends AbstractSnapshotChangeE
                 previousOffset.updateWalPosition(part, finalOpId);
 
                 tabletSafeTime.put(part.getId(), resp.getResp().getSafeHybridTime());
+                } finally {
+                    YugabyteDBTaskContext.clearTabletContext();
+                }
             }
-            
+
             // Reset the retry count here indicating that if the flow has reached here then
             // everything succeeded without any exceptions
             retryCount = 0;

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -464,6 +464,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                             final String tabletId = entry.getValue();
                             curTabletId = entry.getValue();
                             YBPartition part = new YBPartition(entry.getKey() /* tableId */, tabletId, false /* colocated */);
+                            YugabyteDBTaskContext.setTabletContext(entry.getKey(), tabletId);
+                            try {
 
                             OpId cp = offsetContext.lsn(part);
 
@@ -542,7 +544,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 }
                             } catch (CDCErrorException cdcException) {
                                 // Check if exception indicates a tablet split.
-                                LOGGER.info("Code received in CDCErrorException: {}", cdcException.getCDCError().getCode());
+                                LOGGER.info("Code received in CDCErrorException for tablet {}: {}", tabletId, cdcException.getCDCError().getCode());
                                 if (cdcException.getCDCError().getCode() == Code.TABLET_SPLIT || cdcException.getCDCError().getCode() == Code.INVALID_REQUEST) {
                                     LOGGER.info("Encountered a tablet split on tablet {}, handling it gracefully", tabletId);
                                     if (LOGGER.isDebugEnabled()) {
@@ -580,8 +582,8 @@ public class YugabyteDBStreamingChangeEventSource implements
                                 }
                             }
 
-                            LOGGER.debug("Processing {} records from getChanges call",
-                                    response.getResp().getCdcSdkProtoRecordsList().size());
+                            LOGGER.debug("Processing {} records from getChanges call for tablet {}",
+                                    response.getResp().getCdcSdkProtoRecordsList().size(), tabletId);
                             for (CdcService.CDCSDKProtoRecordPB record : response
                                     .getResp()
                                     .getCdcSdkProtoRecordsList()) {
@@ -760,7 +762,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                                         maybeWarnAboutGrowingWalBacklog(dispatched);
                                     }
                                 } catch (InterruptedException ie) {
-                                    LOGGER.error("Interrupted exception while processing change records", ie);
+                                    LOGGER.error("Interrupted exception while processing change records for tablet {}", tabletId, ie);
                                     Thread.currentThread().interrupt();
                                 }
                             }
@@ -798,6 +800,9 @@ public class YugabyteDBStreamingChangeEventSource implements
                             }
 
                             LOGGER.debug("The final opid for tablet {} is {}", part.getId(), finalOpid);
+                            } finally {
+                                YugabyteDBTaskContext.clearTabletContext();
+                            }
                         }
                         // Reset the retry count, because if flow reached at this point, it means that the connection
                         // has succeeded

--- a/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTaskContext.java
+++ b/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBTaskContext.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.CommonConnectorConfig;
@@ -94,6 +95,28 @@ public class YugabyteDBTaskContext extends CdcSourceTaskContext {
                 .doSnapshot(doSnapshot)
                 .withSchema(schema)
                 .build();
+    }
+
+    /**
+     * Set MDC context for the tablet currently being processed. This adds
+     * {@code dbz.tableId} and {@code dbz.tabletId} to the SLF4J MDC so that
+     * every log line emitted during per-tablet processing automatically
+     * carries tablet identification.
+     *
+     * @param tableId the table UUID
+     * @param tabletId the tablet UUID
+     */
+    public static void setTabletContext(String tableId, String tabletId) {
+        MDC.put("dbz.tableId", tableId);
+        MDC.put("dbz.tabletId", tabletId);
+    }
+
+    /**
+     * Clear the tablet MDC context previously set by {@link #setTabletContext}.
+     */
+    public static void clearTabletContext() {
+        MDC.remove("dbz.tableId");
+        MDC.remove("dbz.tabletId");
     }
 
     @Override

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
     <appender name="CONSOLE"
         class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n</pattern>
+            <pattern>%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}|%X{dbz.tableId}|%X{dbz.tabletId}  %m   [%c]%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Add SLF4J MDC keys (dbz.tableId, dbz.tabletId) that are automatically set
during per-tablet processing loops in streaming, snapshot, and consistent
streaming sources. This ensures every log line emitted within tablet
processing carries tablet identification, even for generic messages,
utility methods, and error handlers.

Changes:
- Add setTabletContext/clearTabletContext helpers to YugabyteDBTaskContext
- Wrap per-tablet loops with MDC set/clear in try/finally blocks
- Fix ~11 log statements that were missing tablet/table context
- Update logback-test.xml pattern to include new MDC keys